### PR TITLE
We publish now the vmdk and not OVA/OVF

### DIFF
--- a/Documentation/boards/ova.md
+++ b/Documentation/boards/ova.md
@@ -1,0 +1,14 @@
+# OVA
+
+The OVA stay for open virtual appliance. Currently we had remove the ova files and publish a vmdk virtual disk,
+until we have better OVF template to generate our OVA. This vmdk work with (maybe you need convert the disk):
+- HyperV
+- VirtualBox
+- VMware
+
+## Virtual Machine
+
+You can use this vmdk in a virtual machine with follow requirements:
+- UEFI boot
+- min. 1GB RAM
+- 2 vcpu

--- a/scripts/upload-rel.sh
+++ b/scripts/upload-rel.sh
@@ -30,7 +30,7 @@ fi
 # Upload asset
 echo "[Info] Start Uploading asset... "
 
-for filename in release/*.{gz,raucb}; do
+for filename in release/*; do
     echo "[Info] Start upload ${filename}"
 
     # Construct url


### PR DESCRIPTION
Look like the virtualbox OVF template make troubles. Until we have a better OVF template,
we publish the vmdk file and make a documentation how you can use that with:
- hyperv
- vmware
- virtualbox
- qemu