### PR TITLE
Do not assume index 0 for boot medium

### DIFF
--- a/buildroot-external/bootloader/barebox/boot/system0
+++ b/buildroot-external/bootloader/barebox/boot/system0
@@ -3,6 +3,6 @@
 global linux.bootargs.dyn.root="root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"
 
 mkdir -p /mnt/system
-mount -t ext4 /dev/disk0.hassos-kernel0 /mnt/system
+mount -t ext4 /dev/disk*.hassos-kernel0 /mnt/system
 
 global bootm.image="/mnt/system/bzImage"

--- a/buildroot-external/bootloader/barebox/boot/system1
+++ b/buildroot-external/bootloader/barebox/boot/system1
@@ -3,6 +3,6 @@
 global linux.bootargs.dyn.root="root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=squashfs ro"
 
 mkdir -p /mnt/system
-mount -t ext4 /dev/disk0.hassos-kernel1 /mnt/system
+mount -t ext4 /dev/disk*.hassos-kernel1 /mnt/system
 
 global bootm.image="/mnt/system/bzImage"


### PR DESCRIPTION
When booting the HassOS VMDK appliance disk image on QEMU with OVMF UEFI
firmware, barebox numbers devices differently from other environments.

This patch makes the barebox `sh` implementation expand a pathname
wildcard at runtime, so that assigned disk indices != 0 will also work.

This fix introduces a potential (but most likely irrelevant)
bug/problem: If there is more than one disk connected to the system with
a matching name assigned, the wildcard will expand to two or more
pathnames, breaking the resulting `mount` command.