### PR TITLE
Update documentation for a static IPV4 address via nmcli

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -97,6 +97,36 @@ If you have trouble with powersave you can do following:
 # Values are 0 (use default), 1 (ignore/don't touch), 2 (disable) or 3 (enable).
 powersave=0
 ```
+## Using nmcli to set a static IPV4 address
+
+this method has been tested with a Hass.io image on an Esxi server. Log into the HASSOS base system via a console – note this is not the same as an SSH login via the add-on.
+```
+Welcome to HassOS
+Hassio login:
+```
+Login as `root` (no password needed)
+
+At the `hassio >` prompt, type `login` (as instructed).
+
+From here you will use the `nmcli` configuration tool.
+
+`# nmcli connection show` will list the “HassOS default” connection in use.
+
+`# nmcli con edit “HassOS default”` will put you in a position to edit the connection.
+
+`nmcli> print ipv4` will show you the ipv4 properties of this connection.
+
+To add your static IP address (select 'yes' for manual method);
+```
+nmcli> set ipv4.addresses 192.168.100.10/24
+Do you also want to set 'ipv4.method' to 'manual'? [yes]:
+nmcli> save
+nmcli> exit
+```
+
+If you now view the default connection `cat /etc/NetworkManager/system_connections/default` you should see the method is manual and the address is set.
+
+Doing a `nmcli con reload` does not always work so restart the VM.
 
 [keyfile]: https://developer.gnome.org/NetworkManager/stable/nm-settings.html
 [configuration-usb]: configuration.md

--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -99,7 +99,8 @@ powersave=0
 ```
 ## Using nmcli to set a static IPV4 address
 
-this method has been tested with a Hass.io image on an Esxi server. Log into the HASSOS base system via a console – note this is not the same as an SSH login via the add-on.
+Log into the HASSOS base system via a console:
+
 ```
 Welcome to HassOS
 Hassio login:

--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -112,6 +112,8 @@ From here you will use the `nmcli` configuration tool.
 
 `# nmcli connection show` will list the “HassOS default” connection in use.
 
+`# nmcli con show "HassOS default"` will list all the properties of the connection.
+
 `# nmcli con edit “HassOS default”` will put you in a position to edit the connection.
 
 `nmcli> print ipv4` will show you the ipv4 properties of this connection.
@@ -120,6 +122,11 @@ To add your static IP address (select 'yes' for manual method);
 ```
 nmcli> set ipv4.addresses 192.168.100.10/24
 Do you also want to set 'ipv4.method' to 'manual'? [yes]:
+```
+In addition I have found it is wise to set the dns server and the local gateway.  For most home routers these will be the same address.  If you are using Pi-Hole you can set the dns to that.
+```
+nmcli> set ipv4.dns 192.168.100.1
+nmcli> set ipv4.gateway 192.168.100.1
 nmcli> save
 nmcli> exit
 ```


### PR DESCRIPTION
In looking for a way to set a static IPV4 address on a Esxi hosted Hassio, I discovered this method using the NetworkManager CLI (nmcli).  I felt it might be good to document it.

Happy for the formatting to be modified to suit local convention.

I cannot be more specific about how to get into the base OS as I don't know!