### PR TITLE
Add info telling a new user where the config files are, and how they might get to them

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -22,6 +22,11 @@ API/UI or by calling `systemctl restart hassos-config` on the host.
 
 ## Local
 
+### Home Assistant config files
+
+The Home Assistant config files (like `configuration.yaml` and `customize.yaml`) can be found in the `/config/` dir.
+You can add the SSH Add-On to access the filesystem directly.
+
 ### Bootargs
 
 You can edit or create a `cmdline.txt` in your boot partition. That will be read from the bootloader.


### PR DESCRIPTION
I spent way too long trying to find the docs telling me where the files where