### PR TITLE
Fixed typo in 'address' property name for Static IP

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -72,7 +72,7 @@ Replace follow configuration:
 ```ini
 [ipv4]
 method=manual
-address1=192.168.1.111/24,192.168.1.1
+address=192.168.1.111/24,192.168.1.1
 dns=8.8.8.8;8.8.4.4;
 ```
 


### PR DESCRIPTION
Couldnt get the Static IP to work for my setup after I did some copy-pasta setup. Turns out there was a typo in the sample code provided. This PR simply fixes that typo to save future copy-pasta makers the confusion. 