### PR TITLE
Implement basic ACPI shutdown support via busybox acpid

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/acpi/PWRF/00000080
+++ b/buildroot-external/rootfs-overlay/etc/acpi/PWRF/00000080
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This script is exec()d by acpid when an ACPI event signals the power button
+# to have been pressed.
+
+echo "System power button was pressed - shutting down..."
+exec /bin/systemctl poweroff

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/multi-user.target.wants/busybox-acpid.service
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/multi-user.target.wants/busybox-acpid.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/busybox-acpid.service

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/busybox-acpid.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/busybox-acpid.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=acpid (busybox)
+RefuseManualStop=true
+ConditionPathIsDirectory=/proc/acpi
+
+[Service]
+Type=simple
+ExecStart=/sbin/acpid -d
+
+[Install]
+After=local-fs.target
+WantedBy=multi-user.target


### PR DESCRIPTION
On systems where ACPI support is present as inidcated by the presence of
/proc/acpi (e.g. on OVA compatible hypervisors), we want to properly
shut down the system when the power button is pressed (or the hypervisor
simulates this kind of event to the guest machine that executes hassos).

This changeset provides the following basic infrastructure for this
feature to work as expected:

 * a systemd service to start acpid, if ACPI support can be assumed
 * an acpid configuration directory
 * a trivial shutdown script to invoke when a PWR event is registered

Tested locally with the OVA image/target under qemu. I've taken care not to intefere with platforms without ACPI support, but I did not test those.