### PR TITLE
Allow udev rules & make it persistent

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -8,12 +8,14 @@ Format a USB stick with FAT32/EXT4/NTFS and name it `CONFIG`. Use the following 
 ```text
 network/
 modules/
+udev/
 authorized_keys
 hassos-xy.raucb
 ```
 
 - The `network` folder can contain any kind of NetworkManager connection files. For more information see [Network][network.md]. 
 - The `modules` folder is for modules-load configuration files.
+- The `udev` folder is for udev rules files.
 - The `authorized_keys` file activates debug SSH access on port `22222`. See [Debugging Hassio][debug-hassio].
 - The `hassos-*.raucb` file is a firmware OTA update which will be installed. These can be found on on the [release][hassos-release] page. 
 
@@ -29,6 +31,10 @@ You can edit or create a `cmdline.txt` in your boot partition. That will be read
 ### Kernel-Module
 
 The kernel module folder `/etc/modules-load.d` is persistent and you can add your configuration files there. See [Systemd modules load][systemd-modules].
+
+### Udev rules
+
+The udev rules folder `/etc/udev/rules.d` is persistent and you can add your configuration files there.
 
 ### Network
 

--- a/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
+++ b/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
@@ -24,8 +24,8 @@ define BLUETOOTH_BCM43XX_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm
 	$(INSTALL) -m 0644 $(@D)/*.hcd $(TARGET_DIR)/lib/firmware/brcm/
 
-	$(INSTALL) -d $(TARGET_DIR)/etc/udev/rules.d
-	$(INSTALL) -m 0644 $(@D)/bluetooth-bcm43xx.rules $(TARGET_DIR)/etc/udev/rules.d/
+	$(INSTALL) -d $(TARGET_DIR)/usr/lib/udev/rules.d
+	$(INSTALL) -m 0644 $(@D)/bluetooth-bcm43xx.rules $(TARGET_DIR)/usr/lib/udev/rules.d/
 endef
 
 $(eval $(generic-package))

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/hassos-bind.target.wants/etc-udev-rules.d.mount
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/hassos-bind.target.wants/etc-udev-rules.d.mount
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/etc-udev-rules.d.mount

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-udev-rules.d.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-udev-rules.d.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Udev persistent rules.d
+Requires=mnt-overlay.mount
+After=mnt-overlay.mount
+Before=systemd-udevd.service hassos-config.service
+
+[Mount]
+What=/mnt/overlay/etc/udev/rules.d
+Where=/etc/udev/rules.d
+Type=None
+Options=bind
+
+[Install]
+WantedBy=hassos-bind.target

--- a/buildroot-external/rootfs-overlay/usr/lib/udev/rules.d/hmip-rfusb.rules
+++ b/buildroot-external/rootfs-overlay/usr/lib/udev/rules.d/hmip-rfusb.rules
@@ -1,0 +1,1 @@
+ACTION=="add", ATTRS{idVendor}=="1b1f", ATTRS{idProduct}=="c020", RUN+="/sbin/modprobe cp210x" RUN+="/bin/sh -c 'echo 1b1f c020 >/sys/bus/usb-serial/drivers/cp210x/new_id'"

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -34,6 +34,15 @@ if [ -d /mnt/config/modules ]; then
 fi
 
 ##
+# Udev
+if [ -d /mnt/config/udev ]; then
+    echo "[Info] Update Udev configuration!"
+
+    rm -rf /etc/udev/rules.d/*
+    cp -f /mnt/config/udev/* /etc/udev/rules.d/*
+fi
+
+##
 # SSH know hosts
 if [ -f /mnt/config/authorized_keys ]; then
     echo "[Info] Update SSH authorized_keys!"

--- a/buildroot-external/scripts/rauc.sh
+++ b/buildroot-external/scripts/rauc.sh
@@ -86,7 +86,7 @@ function install_bootloader_config() {
 
     # Fix MBR
     if [ "${BOOT_SYS}" == "mbr" ]; then
-        mkdir -p ${TARGET_DIR}/etc/udev/rules.d
-	cp -f ${BR2_EXTERNAL_HASSOS_PATH}/misc/mbr-part.rules ${TARGET_DIR}/etc/udev/rules.d/
+        mkdir -p ${TARGET_DIR}/usr/lib/udev/rules.d
+	cp -f ${BR2_EXTERNAL_HASSOS_PATH}/misc/mbr-part.rules ${TARGET_DIR}/usr/lib/udev/rules.d/
     fi
 }


### PR DESCRIPTION
- Add udev rules to configuration automation
- Set HassOS udev rules for devices
- Enable persistent user udev rules