### PR TITLE
OS: Config importer support now also boot partition

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -3,7 +3,7 @@
 ## Automatic
 
 You can use an USB drive with HassOS to configure network options, SSH access to the host and to install updates.
-Format a USB stick with FAT32/EXT4/NTFS and name it `CONFIG`. Use the following directory structure within the USB drive:
+Format a USB stick with FAT32/EXT4/NTFS and name it `CONFIG`. Alternative you can create a `CONFIG` folder inside boot partition. Use the following directory structure within the USB drive:
 
 ```text
 network/

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -89,6 +89,8 @@ if ls ${USB_CONFIG}/*.raucb > /dev/null && [ ${UPTIME} -ge 180 ]; then
 fi
 
 # Cleanup config partition
-if [ ${USE_USB} = 0 ]; then
+if [ ${USE_USB} = 1 ]; then
     systemctl stop mnt-config.mount
+else
+    rm -rf ${BOOT_CONFIG}
 fi

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -1,24 +1,41 @@
 #!/bin/sh
 
-if ! findfs LABEL="CONFIG" > /dev/null; then
+BOOT_CONFIG="/mnt/boot/CONFIG"
+USB_CONFIG="/mnt/config"
+CONFIG_DIR=""
+USE_USB=0
+
+# Check and mount usb CONFIG to folder
+if findfs LABEL="CONFIG" > /dev/null; then
+    echo "[Info] Use USB stick for import CONFIG"
+
+    systemctl start mnt-config.mount
+    if ! systemctl -q is-active mnt-config.mount; then
+        echo "[Error] Can't mount config partition"
+        exit 1
+    fi
+
+    USE_USB=1
+    CONFIG_DIR=${USB_CONFIG}
+fi
+
+# Use boot CONFIG folder
+if [ ${USE_USB} = 0 ] && [ -d ${BOOT_CONFIG} ]; then
+    echo "[Info] Use boot partition for import CONFIG"
+    CONFIG_DIR=${BOOT_CONFIG}
+elif [ ${USE_USB} = 0 ]; then
     echo "[Warning] No config partition found"
     exit 0
 fi
 
-# Mount config folder
-systemctl start mnt-config.mount
-if ! systemctl -q is-active mnt-config.mount; then
-    echo "[Error] Can't mount config partition"
-    exit 1
-fi
 
 ##
 # NetworkManager
-if [ -d /mnt/config/network ]; then
+if [ -d "${CONFIG_DIR}/network" ]; then
     echo "[Info] Update NetworkManager connections!"
 
     rm -rf /etc/NetworkManager/system-connections/*
-    cp -f /mnt/config/network/* /etc/NetworkManager/system-connections/
+    cp -f ${CONFIG_DIR}/network/* /etc/NetworkManager/system-connections/
     chmod 600 /etc/NetworkManager/system-connections/*
 
     nmcli con reload
@@ -26,28 +43,28 @@ fi
 
 ##
 # Modules
-if [ -d /mnt/config/modules ]; then
+if [ -d "${CONFIG_DIR}/modules" ]; then
     echo "[Info] Update Modules configuration!"
 
     rm -rf /etc/modules-load.d/*
-    cp -f /mnt/config/modules/* /etc/modules-load.d/*
+    cp -f ${CONFIG_DIR}/modules/* /etc/modules-load.d/*
 fi
 
 ##
 # Udev
-if [ -d /mnt/config/udev ]; then
+if [ -d "${CONFIG_DIR}/udev" ]; then
     echo "[Info] Update Udev configuration!"
 
     rm -rf /etc/udev/rules.d/*
-    cp -f /mnt/config/udev/* /etc/udev/rules.d/*
+    cp -f ${CONFIG_DIR}/udev/* /etc/udev/rules.d/*
 fi
 
 ##
 # SSH know hosts
-if [ -f /mnt/config/authorized_keys ]; then
+if [ -f "${CONFIG_DIR}/authorized_keys" ]; then
     echo "[Info] Update SSH authorized_keys!"
 
-    cp -f /mnt/config/authorized_keys /root/.ssh/authorized_keys
+    cp -f ${CONFIG_DIR}/authorized_keys /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
 
     systemctl start dropbear
@@ -57,13 +74,13 @@ else
 fi
 
 ##
-# Firmware update
+# Firmware update / Only USB
 UPTIME=$(awk '{printf "%0.f", $1}' /proc/uptime)
-if ls /mnt/config/*.raucb > /dev/null && [ ${UPTIME} -ge 180 ]; then
+if ls ${USB_CONFIG}/*.raucb > /dev/null && [ ${UPTIME} -ge 180 ]; then
     echo "[Info] Performe a firmware update"
 
-    rauc_filename=$(ls /mnt/config/*.raucb | head -n 1)
-    if rauc install ${rauc_filename}; then
+    rauc_filename=$(ls ${USB_CONFIG}/*.raucb | head -n 1)
+    if rauc install "${rauc_filename}"; then
         echo "[Info] Firmware update success"
         systemctl reboot
     else
@@ -72,4 +89,6 @@ if ls /mnt/config/*.raucb > /dev/null && [ ${UPTIME} -ge 180 ]; then
 fi
 
 # Cleanup config partition
-systemctl stop mnt-config.mount
+if [ ${USE_USB} = 0 ]; then
+    systemctl stop mnt-config.mount
+fi

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -6,7 +6,7 @@ CONFIG_DIR=""
 USE_USB=0
 
 # Check and mount usb CONFIG to folder
-if findfs LABEL="CONFIG" > /dev/null; then
+if findfs LABEL="CONFIG" > /dev/null 2>&1; then
     echo "[Info] Use USB stick for import CONFIG"
 
     systemctl start mnt-config.mount
@@ -38,7 +38,7 @@ if [ -d "${CONFIG_DIR}/network" ]; then
     cp -f ${CONFIG_DIR}/network/* /etc/NetworkManager/system-connections/
     chmod 600 /etc/NetworkManager/system-connections/*
 
-    nmcli con reload
+    nmcli con reload > /dev/null 2>&1
 fi
 
 ##
@@ -67,16 +67,18 @@ if [ -f "${CONFIG_DIR}/authorized_keys" ]; then
     cp -f ${CONFIG_DIR}/authorized_keys /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
 
-    systemctl start dropbear
+    systemctl start dropbear > /dev/null 2>&1
 else
+    echo "[Info] Stop SSH debug access"
+
     rm -f /root/.ssh/authorized_keys
-    systemctl stop dropbear
+    systemctl stop dropbear > /dev/null 2>&1
 fi
 
 ##
 # Firmware update / Only USB
 UPTIME=$(awk '{printf "%0.f", $1}' /proc/uptime)
-if ls ${USB_CONFIG}/*.raucb > /dev/null && [ ${UPTIME} -ge 180 ]; then
+if ls ${USB_CONFIG}/*.raucb > /dev/null 2>&1 && [ ${UPTIME} -ge 180 ]; then
     echo "[Info] Performe a firmware update"
 
     rauc_filename=$(ls ${USB_CONFIG}/*.raucb | head -n 1)


### PR DESCRIPTION
fix: #182 

Device like RPi zero have no USB stick. It allow also to simple set a config with boot partition (Fat32) after write a the SD card and need no extra device.

With support config per boot partition and with a USB stick, we could support any case to setup a device unattended.