### PR TITLE
Add hidden=true comment for Wifi routers not broadcasting SSID

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -51,6 +51,8 @@ type=802-11-wireless
 [802-11-wireless]
 mode=infrastructure
 ssid=MY_SSID
+# Uncomment below if your SSID is not broadcasted
+#hidden=true
 
 [802-11-wireless-security]
 auth-alg=open


### PR DESCRIPTION
A simple comment that would have saved me a lot of time troubleshooting why Hassos was not connecting to my wifi router.

Reference to this setting: https://developer.gnome.org/NetworkManager/stable/settings-802-11-wireless.html