### PR TITLE
Don't use a bind mount for docker data

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/docker.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/docker.service.d/hassos.conf
@@ -3,4 +3,4 @@ RequiresMountsFor=/etc/docker /var/lib/docker
 
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --log-driver=journald
+ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2 --log-driver=journald --data-root /mnt/data/docker


### PR DESCRIPTION
I hope that fixes the problem with corrupt databases after power off.