### PR TITLE
Update timesyncd.conf

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/timesyncd.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/timesyncd.conf
@@ -1,3 +1,3 @@
 [Time]
-NTP=time1.google.com time2.google.com time3.google.com
-FallbackNTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+NTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+FallbackNTP=time1.google.com time2.google.com time3.google.com


### PR DESCRIPTION
Set the default NTP servers to ntp.pool.org and Google NTP as fallback, avoiding defaulting to a less open and transparent service.