### PR TITLE
OS: Run ash as login shell, so $PATH is set correctly.

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -20,9 +20,9 @@ docker container run \
     $DOCKER_ARGS \
     "${CLI}"
 
-# Jump to root shell
+# Jump to root login shell
 if [ $? -eq 10 ]; then
-    /bin/ash
+    /bin/ash -l
 fi
 
 exit


### PR DESCRIPTION
Run ash as login shell will source /etc/profile where the `/sbin` and `/usr/sbin` are included in the path. Side effect is that `PS1` will be different from the current situation. Part of solution for #250.