### PR TITLE
Migrate from LABEL= to /dev/disk/by-label/*

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/hassos-bind.target.wants/hassos-user-rules-udev-trigger.service
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/hassos-bind.target.wants/hassos-user-rules-udev-trigger.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/hassos-user-rules-udev-trigger.service

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-udev-rules.d.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-udev-rules.d.mount
@@ -2,7 +2,7 @@
 Description=Udev persistent rules.d
 Requires=mnt-overlay.mount
 After=mnt-overlay.mount
-Before=systemd-udevd.service hassos-config.service
+Before=hassos-config.service
 
 [Mount]
 What=/mnt/overlay/etc/udev/rules.d

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-expand.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-expand.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 Before=mnt-data.mount
 RefuseManualStart=true
 RefuseManualStop=true
+Requires=dev-disk-by\x2dlabel-hassos\x2ddata.device
+After=dev-disk-by\x2dlabel-hassos\x2ddata.device
 
 [Service]
 Type=oneshot

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-user-rules-udev-trigger.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-user-rules-udev-trigger.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Retrigger udev rules after user rules mounted
+DefaultDependencies=no
+Wants=systemd-udevd.service etc-udev-rules.d.mount
+After=systemd-udev-trigger.service etc-udev-rules.d.mount
+Before=hassos-bind.target
+ConditionPathIsReadWrite=/sys
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/udevadm control --reload-rules
+ExecStart=/usr/bin/udevadm trigger --type=subsystems --action=add
+ExecStart=/usr/bin/udevadm trigger --type=devices --action=add
+
+[Install]
+WantedBy=hassos-bind.target

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
@@ -6,7 +6,7 @@ After=local-fs.target
 Conflicts=umount.target
 
 [Mount]
-What=LABEL=hassos-boot
+What=/dev/disk/by-label/hassos-boot
 Where=/mnt/boot
 Type=auto
 

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-config.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-config.mount
@@ -2,7 +2,7 @@
 Description=HassOS config partition
 
 [Mount]
-What=LABEL=CONFIG
+What=/dev/disk/by-label/CONFIG
 Where=/mnt/config
 Type=auto
 Options=ro

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
@@ -7,7 +7,7 @@ Before=umount.target systemd-tmpfiles-setup.service
 Conflicts=umount.target
 
 [Mount]
-What=LABEL=hassos-data
+What=/dev/disk/by-label/hassos-data
 Where=/mnt/data
 Type=ext4
 

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-overlay.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-overlay.mount
@@ -5,7 +5,7 @@ Before=umount.target systemd-tmpfiles-setup.service
 Conflicts=umount.target
 
 [Mount]
-What=LABEL=hassos-overlay
+What=/dev/disk/by-label/hassos-overlay
 Where=/mnt/overlay
 Type=ext4
 


### PR DESCRIPTION
Hey folks—this is my first patch against HassOS. First, let me just say that this project is _wonderful,_ and while I'm a relative newcomer to it and to Home Assistant in general, working with Hass/Hassio/HassOS so far has been so much fun.

I wanted to see if y'all would be willing to accept a patch like this one. I'm admittedly running HassOS in a slightly unsupported configuration (basically, with a `hassos-data` volume on an external storage device, not on my RPi's SD card). Unsurprisingly, this works quite well, *except* that maybe 50% of the time, my external volume isn't available until a few seconds after the `hassos-expand.service` unit wants to start. This, in turn, causes that unit to fail, and then any dependent units fail, like `mnt-data.mount`, leaving the system unable to start.

Digging into the systemd source, my belief is that use of the `LABEL=` syntax [causes systemd](https://github.com/systemd/systemd/blob/ee0b9e721a368742ac6fa9c3d9a33e45dc3203a2/src/core/mount.c#L333) not to associate any block device dependencies with the mount, meaning that if a hotplug device isn't available, systemd won't wait for it. If we use `/dev/device/by-label/hassos-data`, say, all the dependencies should be wired up and everything should work.

Because the `hassos-expand.service` depends on the filesystem not being mounted, I added an explicit dependency to this unit.

I still need to do some (any?) extensive testing on this, but I'd love some feedback on the approach, and—despite the fact that I'm personally using it to run HassOS in a slightly off-label fashion—whether you'd accept it upstream, as it likely would improve the resiliency of the software in the face of wonky hardware even outside of my use-case.

Anyway, thank you so much for even reading this PR, and thanks for all the work that you do on HA!