### PR TITLE
OS: Fix unmount of busy mounts

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-lib-NetworkManager.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-lib-NetworkManager.mount
@@ -9,6 +9,7 @@ What=/mnt/overlay/var/lib/NetworkManager
 Where=/var/lib/NetworkManager
 Type=none
 Options=bind
+LazyUnmount=yes
 
 [Install]
 WantedBy=hassos-bind.target

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-log-journal.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-log-journal.mount
@@ -9,6 +9,7 @@ What=/mnt/overlay/var/log/journal
 Where=/var/log/journal
 Type=None
 Options=bind
+LazyUnmount=yes
 
 [Install]
 WantedBy=hassos-bind.target


### PR DESCRIPTION
dhclient and systemd-journald will be running during shutdown and are
only killed in the final shutdown fase. Unmounting the directories
they use will fail. Use lazy unmouting to fix this. Fixes #314 