### PR TITLE
Fix cve-2019-5736

### DIFF
--- a/buildroot-external/patches/runc/0048-nsenter-clone-proc-self-exe-to-avoid-exposing-host-b.patch
+++ b/buildroot-external/patches/runc/0048-nsenter-clone-proc-self-exe-to-avoid-exposing-host-b.patch
@@ -1,0 +1,337 @@
+From 0a8e4117e7f715d5fbeef398405813ce8e88558b Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Wed, 9 Jan 2019 13:40:01 +1100
+Subject: [PATCH 48/50] nsenter: clone /proc/self/exe to avoid exposing host
+ binary to container
+
+There are quite a few circumstances where /proc/self/exe pointing to a
+pretty important container binary is a _bad_ thing, so to avoid this we
+have to make a copy (preferably doing self-clean-up and not being
+writeable).
+
+We require memfd_create(2) -- though there is an O_TMPFILE fallback --
+but we can always extend this to use a scratch MNT_DETACH overlayfs or
+tmpfs. The main downside to this approach is no page-cache sharing for
+the runc binary (which overlayfs would give us) but this is far less
+complicated.
+
+This is only done during nsenter so that it happens transparently to the
+Go code, and any libcontainer users benefit from it. This also makes
+ExtraFiles and --preserve-fds handling trivial (because we don't need to
+worry about it).
+
+Fixes: CVE-2019-5736
+Co-developed-by: Christian Brauner <christian.brauner@ubuntu.com>
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ libcontainer/nsenter/cloned_binary.c | 268 +++++++++++++++++++++++++++
+ libcontainer/nsenter/nsexec.c        |  11 ++
+ 2 files changed, 279 insertions(+)
+ create mode 100644 libcontainer/nsenter/cloned_binary.c
+
+diff --git a/libcontainer/nsenter/cloned_binary.c b/libcontainer/nsenter/cloned_binary.c
+new file mode 100644
+index 00000000..c8a42c23
+--- /dev/null
++++ b/libcontainer/nsenter/cloned_binary.c
+@@ -0,0 +1,268 @@
++/*
++ * Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
++ * Copyright (C) 2019 SUSE LLC
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#define _GNU_SOURCE
++#include <unistd.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <stdbool.h>
++#include <string.h>
++#include <limits.h>
++#include <fcntl.h>
++#include <errno.h>
++
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <sys/vfs.h>
++#include <sys/mman.h>
++#include <sys/sendfile.h>
++#include <sys/syscall.h>
++
++/* Use our own wrapper for memfd_create. */
++#if !defined(SYS_memfd_create) && defined(__NR_memfd_create)
++#  define SYS_memfd_create __NR_memfd_create
++#endif
++#ifdef SYS_memfd_create
++#  define HAVE_MEMFD_CREATE
++/* memfd_create(2) flags -- copied from <linux/memfd.h>. */
++#  ifndef MFD_CLOEXEC
++#    define MFD_CLOEXEC       0x0001U
++#    define MFD_ALLOW_SEALING 0x0002U
++#  endif
++int memfd_create(const char *name, unsigned int flags)
++{
++	return syscall(SYS_memfd_create, name, flags);
++}
++#endif
++
++/* This comes directly from <linux/fcntl.h>. */
++#ifndef F_LINUX_SPECIFIC_BASE
++#  define F_LINUX_SPECIFIC_BASE 1024
++#endif
++#ifndef F_ADD_SEALS
++#  define F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
++#  define F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
++#endif
++#ifndef F_SEAL_SEAL
++#  define F_SEAL_SEAL   0x0001	/* prevent further seals from being set */
++#  define F_SEAL_SHRINK 0x0002	/* prevent file from shrinking */
++#  define F_SEAL_GROW   0x0004	/* prevent file from growing */
++#  define F_SEAL_WRITE  0x0008	/* prevent writes */
++#endif
++
++#define RUNC_SENDFILE_MAX 0x7FFFF000 /* sendfile(2) is limited to 2GB. */
++#ifdef HAVE_MEMFD_CREATE
++#  define RUNC_MEMFD_COMMENT "runc_cloned:/proc/self/exe"
++#  define RUNC_MEMFD_SEALS \
++	(F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)
++#endif
++
++static void *must_realloc(void *ptr, size_t size)
++{
++	void *old = ptr;
++	do {
++		ptr = realloc(old, size);
++	} while(!ptr);
++	return ptr;
++}
++
++/*
++ * Verify whether we are currently in a self-cloned program (namely, is
++ * /proc/self/exe a memfd). F_GET_SEALS will only succeed for memfds (or rather
++ * for shmem files), and we want to be sure it's actually sealed.
++ */
++static int is_self_cloned(void)
++{
++	int fd, ret, is_cloned = 0;
++
++	fd = open("/proc/self/exe", O_RDONLY|O_CLOEXEC);
++	if (fd < 0)
++		return -ENOTRECOVERABLE;
++
++#ifdef HAVE_MEMFD_CREATE
++	ret = fcntl(fd, F_GET_SEALS);
++	is_cloned = (ret == RUNC_MEMFD_SEALS);
++#else
++	struct stat statbuf = {0};
++	ret = fstat(fd, &statbuf);
++	if (ret >= 0)
++		is_cloned = (statbuf.st_nlink == 0);
++#endif
++	close(fd);
++	return is_cloned;
++}
++
++/*
++ * Basic wrapper around mmap(2) that gives you the file length so you can
++ * safely treat it as an ordinary buffer. Only gives you read access.
++ */
++static char *read_file(char *path, size_t *length)
++{
++	int fd;
++	char buf[4096], *copy = NULL;
++
++	if (!length)
++		return NULL;
++
++	fd = open(path, O_RDONLY | O_CLOEXEC);
++	if (fd < 0)
++		return NULL;
++
++	*length = 0;
++	for (;;) {
++		int n;
++
++		n = read(fd, buf, sizeof(buf));
++		if (n < 0)
++			goto error;
++		if (!n)
++			break;
++
++		copy = must_realloc(copy, (*length + n) * sizeof(*copy));
++		memcpy(copy + *length, buf, n);
++		*length += n;
++	}
++	close(fd);
++	return copy;
++
++error:
++	close(fd);
++	free(copy);
++	return NULL;
++}
++
++/*
++ * A poor-man's version of "xargs -0". Basically parses a given block of
++ * NUL-delimited data, within the given length and adds a pointer to each entry
++ * to the array of pointers.
++ */
++static int parse_xargs(char *data, int data_length, char ***output)
++{
++	int num = 0;
++	char *cur = data;
++
++	if (!data || *output != NULL)
++		return -1;
++
++	while (cur < data + data_length) {
++		num++;
++		*output = must_realloc(*output, (num + 1) * sizeof(**output));
++		(*output)[num - 1] = cur;
++		cur += strlen(cur) + 1;
++	}
++	(*output)[num] = NULL;
++	return num;
++}
++
++/*
++ * "Parse" out argv and envp from /proc/self/cmdline and /proc/self/environ.
++ * This is necessary because we are running in a context where we don't have a
++ * main() that we can just get the arguments from.
++ */
++static int fetchve(char ***argv, char ***envp)
++{
++	char *cmdline = NULL, *environ = NULL;
++	size_t cmdline_size, environ_size;
++
++	cmdline = read_file("/proc/self/cmdline", &cmdline_size);
++	if (!cmdline)
++		goto error;
++	environ = read_file("/proc/self/environ", &environ_size);
++	if (!environ)
++		goto error;
++
++	if (parse_xargs(cmdline, cmdline_size, argv) <= 0)
++		goto error;
++	if (parse_xargs(environ, environ_size, envp) <= 0)
++		goto error;
++
++	return 0;
++
++error:
++	free(environ);
++	free(cmdline);
++	return -EINVAL;
++}
++
++static int clone_binary(void)
++{
++	int binfd, memfd;
++	ssize_t sent = 0;
++
++#ifdef HAVE_MEMFD_CREATE
++	memfd = memfd_create(RUNC_MEMFD_COMMENT, MFD_CLOEXEC | MFD_ALLOW_SEALING);
++#else
++	memfd = open("/tmp", O_TMPFILE | O_EXCL | O_RDWR | O_CLOEXEC, 0711);
++#endif
++	if (memfd < 0)
++		return -ENOTRECOVERABLE;
++
++	binfd = open("/proc/self/exe", O_RDONLY | O_CLOEXEC);
++	if (binfd < 0)
++		goto error;
++
++	sent = sendfile(memfd, binfd, NULL, RUNC_SENDFILE_MAX);
++	close(binfd);
++	if (sent < 0)
++		goto error;
++
++#ifdef HAVE_MEMFD_CREATE
++	int err = fcntl(memfd, F_ADD_SEALS, RUNC_MEMFD_SEALS);
++	if (err < 0)
++		goto error;
++#else
++	/* Need to re-open "memfd" as read-only to avoid execve(2) giving -EXTBUSY. */
++	int newfd;
++	char *fdpath = NULL;
++
++	if (asprintf(&fdpath, "/proc/self/fd/%d", memfd) < 0)
++		goto error;
++	newfd = open(fdpath, O_RDONLY | O_CLOEXEC);
++	free(fdpath);
++	if (newfd < 0)
++		goto error;
++
++	close(memfd);
++	memfd = newfd;
++#endif
++	return memfd;
++
++error:
++	close(memfd);
++	return -EIO;
++}
++
++int ensure_cloned_binary(void)
++{
++	int execfd;
++	char **argv = NULL, **envp = NULL;
++
++	/* Check that we're not self-cloned, and if we are then bail. */
++	int cloned = is_self_cloned();
++	if (cloned > 0 || cloned == -ENOTRECOVERABLE)
++		return cloned;
++
++	if (fetchve(&argv, &envp) < 0)
++		return -EINVAL;
++
++	execfd = clone_binary();
++	if (execfd < 0)
++		return -EIO;
++
++	fexecve(execfd, argv, envp);
++	return -ENOEXEC;
++}
+diff --git a/libcontainer/nsenter/nsexec.c b/libcontainer/nsenter/nsexec.c
+index 28269dfc..7750af35 100644
+--- a/libcontainer/nsenter/nsexec.c
++++ b/libcontainer/nsenter/nsexec.c
+@@ -534,6 +534,9 @@ void join_namespaces(char *nslist)
+ 	free(namespaces);
+ }
+ 
++/* Defined in cloned_binary.c. */
++extern int ensure_cloned_binary(void);
++
+ void nsexec(void)
+ {
+ 	int pipenum;
+@@ -549,6 +552,14 @@ void nsexec(void)
+ 	if (pipenum == -1)
+ 		return;
+ 
++	/*
++	 * We need to re-exec if we are not in a cloned binary. This is necessary
++	 * to ensure that containers won't be able to access the host binary
++	 * through /proc/self/exe. See CVE-2019-5736.
++	 */
++	if (ensure_cloned_binary() < 0)
++		bail("could not ensure we are a cloned binary");
++
+ 	/* Parse all of the netlink configuration. */
+ 	nl_parse(pipenum, &config);
+ 
+-- 
+2.17.1
+

--- a/buildroot-external/patches/runc/0050-nsexec-CVE-2019-5736-avoid-parsing-environ.patch
+++ b/buildroot-external/patches/runc/0050-nsexec-CVE-2019-5736-avoid-parsing-environ.patch
@@ -1,0 +1,106 @@
+From bb7d8b1f41f7bf0399204d54009d6da57c3cc775 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Thu, 14 Feb 2019 15:56:26 +0100
+Subject: [PATCH 50/50] nsexec (CVE-2019-5736): avoid parsing environ
+
+My first attempt to simplify this and make it less costly focussed on
+the way constructors are called. I was under the impression that the ELF
+specification mandated that arg, argv, and actually even envp need to be
+passed to functions located in the .init_arry section (aka
+"constructors"). Actually, the specifications is (cf. [2]):
+
+SHT_INIT_ARRAY
+This section contains an array of pointers to initialization functions,
+as described in ``Initialization and Termination Functions'' in Chapter
+5. Each pointer in the array is taken as a parameterless procedure with
+a void return.
+
+which means that this becomes a libc specific decision. Glibc passes
+down those args, musl doesn't. So this approach can't work. However, we
+can at least remove the environment parsing part based on POSIX since
+[1] mandates that there should be an environ variable defined in
+unistd.h which provides access to the environment. See also the relevant
+Open Group specification [1].
+
+[1]: http://pubs.opengroup.org/onlinepubs/9699919799/
+[2]: http://www.sco.com/developers/gabi/latest/ch4.sheader.html#init_array
+
+Fixes: CVE-2019-5736
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+---
+ libcontainer/nsenter/cloned_binary.c | 23 ++++++++++-------------
+ 1 file changed, 10 insertions(+), 13 deletions(-)
+
+diff --git a/libcontainer/nsenter/cloned_binary.c b/libcontainer/nsenter/cloned_binary.c
+index c8a42c23..c97dfcb7 100644
+--- a/libcontainer/nsenter/cloned_binary.c
++++ b/libcontainer/nsenter/cloned_binary.c
+@@ -169,31 +169,25 @@ static int parse_xargs(char *data, int data_length, char ***output)
+ }
+ 
+ /*
+- * "Parse" out argv and envp from /proc/self/cmdline and /proc/self/environ.
++ * "Parse" out argv from /proc/self/cmdline.
+  * This is necessary because we are running in a context where we don't have a
+  * main() that we can just get the arguments from.
+  */
+-static int fetchve(char ***argv, char ***envp)
++static int fetchve(char ***argv)
+ {
+-	char *cmdline = NULL, *environ = NULL;
+-	size_t cmdline_size, environ_size;
++	char *cmdline = NULL;
++	size_t cmdline_size;
+ 
+ 	cmdline = read_file("/proc/self/cmdline", &cmdline_size);
+ 	if (!cmdline)
+ 		goto error;
+-	environ = read_file("/proc/self/environ", &environ_size);
+-	if (!environ)
+-		goto error;
+ 
+ 	if (parse_xargs(cmdline, cmdline_size, argv) <= 0)
+ 		goto error;
+-	if (parse_xargs(environ, environ_size, envp) <= 0)
+-		goto error;
+ 
+ 	return 0;
+ 
+ error:
+-	free(environ);
+ 	free(cmdline);
+ 	return -EINVAL;
+ }
+@@ -246,23 +240,26 @@ error:
+ 	return -EIO;
+ }
+ 
++/* Get cheap access to the environment. */
++extern char **environ;
++
+ int ensure_cloned_binary(void)
+ {
+ 	int execfd;
+-	char **argv = NULL, **envp = NULL;
++	char **argv = NULL;
+ 
+ 	/* Check that we're not self-cloned, and if we are then bail. */
+ 	int cloned = is_self_cloned();
+ 	if (cloned > 0 || cloned == -ENOTRECOVERABLE)
+ 		return cloned;
+ 
+-	if (fetchve(&argv, &envp) < 0)
++	if (fetchve(&argv) < 0)
+ 		return -EINVAL;
+ 
+ 	execfd = clone_binary();
+ 	if (execfd < 0)
+ 		return -EIO;
+ 
+-	fexecve(execfd, argv, envp);
++	fexecve(execfd, argv, environ);
+ 	return -ENOEXEC;
+ }
+-- 
+2.17.1
+

--- a/buildroot-patches/0001-docker-containerd-bump-to-v1.2.4.patch
+++ b/buildroot-patches/0001-docker-containerd-bump-to-v1.2.4.patch
@@ -1,7 +1,7 @@
 From 0484ba124482874b9612563887b22ce454026f7e Mon Sep 17 00:00:00 2001
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Mon, 26 Nov 2018 14:38:19 +0000
-Subject: [PATCH 1/1] docker-containerd: bump to v1.2.0
+Subject: [PATCH 1/1] docker-containerd: bump to v1.2.4
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---
@@ -16,7 +16,7 @@ index a530873..71cd5e5 100644
 @@ -1,3 +1,3 @@
  # Computed locally
 -sha256	a946f4614d92d60361213ef18deab04ee73599e4567f1ff26f7a72841afe4fa2	docker-containerd-v1.1.3.tar.gz
-+sha256	8565a655345f3db2f7b78b77a2cd3103895229aa44cd0e4c710ba3559e344b5a	docker-containerd-v1.2.0.tar.gz
++sha256	5b23bd330f9e59e14f7dced9e3106f37f5b552e527bb6c1503001d90e853c155	docker-containerd-v1.2.4.tar.gz
  sha256  4bbe3b885e8cd1907ab4cf9a41e862e74e24b5422297a4f2fe524e6a30ada2b4	LICENSE
 diff --git a/package/docker-containerd/docker-containerd.mk b/package/docker-containerd/docker-containerd.mk
 index 121ef09..36f4a25 100644
@@ -27,7 +27,7 @@ index 121ef09..36f4a25 100644
  ################################################################################
  
 -DOCKER_CONTAINERD_VERSION = v1.1.3
-+DOCKER_CONTAINERD_VERSION = v1.2.0
++DOCKER_CONTAINERD_VERSION = v1.2.4
  DOCKER_CONTAINERD_SITE = $(call github,containerd,containerd,$(DOCKER_CONTAINERD_VERSION))
  DOCKER_CONTAINERD_LICENSE = Apache-2.0
  DOCKER_CONTAINERD_LICENSE_FILES = LICENSE

--- a/buildroot/package/docker-containerd/docker-containerd.hash
+++ b/buildroot/package/docker-containerd/docker-containerd.hash
@@ -1,3 +1,3 @@
 # Computed locally
-sha256	8565a655345f3db2f7b78b77a2cd3103895229aa44cd0e4c710ba3559e344b5a	docker-containerd-v1.2.0.tar.gz
+sha256	5b23bd330f9e59e14f7dced9e3106f37f5b552e527bb6c1503001d90e853c155	docker-containerd-v1.2.4.tar.gz
 sha256  4bbe3b885e8cd1907ab4cf9a41e862e74e24b5422297a4f2fe524e6a30ada2b4	LICENSE

--- a/buildroot/package/docker-containerd/docker-containerd.mk
+++ b/buildroot/package/docker-containerd/docker-containerd.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DOCKER_CONTAINERD_VERSION = v1.2.0
+DOCKER_CONTAINERD_VERSION = v1.2.4
 DOCKER_CONTAINERD_SITE = $(call github,containerd,containerd,$(DOCKER_CONTAINERD_VERSION))
 DOCKER_CONTAINERD_LICENSE = Apache-2.0
 DOCKER_CONTAINERD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Hass.io don't use exec, but we fix that for all user they running other stuff on HassOS. We can't update docker to 18.09.2 because the audio is now blocked and we need wait until a feature is available on CLI that we can enable that again.