### PR TITLE
Allow attaching external drive as a backup directory

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
@@ -1,0 +1,15 @@
+[Unit]
+Description=hassio backup partition
+Wants=hassos-expand.service
+DefaultDependencies=no
+After=hassos-expand.service
+Before=umount.target local-fs.target
+Conflicts=umount.target
+
+[Mount]
+What=/dev/disk/by-label/BACKUP
+Where=/mnt/data/supervisor/backup
+Type=ext4
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
if you label a partition "BACKUP", it will be mounted as a backup folder for hassio