### PR TITLE
make clear the usb drive needs to be connected only while configuration

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -3,7 +3,7 @@
 ## Automatic
 
 You can use an USB drive with HassOS to configure network options, SSH access to the host and to install updates.
-Format a USB stick with FAT32/EXT4/NTFS and name it `CONFIG`. Alternative you can create a `CONFIG` folder inside boot partition. Use the following directory structure within the USB drive:
+Format a USB stick with FAT32/EXT4/NTFS and name it `CONFIG` (in all capitals). Alternative you can create a `CONFIG` folder inside boot partition. Use the following directory structure within the USB drive:
 
 ```text
 network/
@@ -23,8 +23,8 @@ hassos-xy.raucb
 - The `timesyncd.conf` file allow you to set different NTP servers. HassOS won't boot without correct working time servers!
 - The `hassos-*.raucb` file is a firmware OTA update which will be installed. These can be found on on the [release][hassos-release] page.
 
-You can put this USB stick into the device and it will be read on startup. You can also trigger this process later over the
-API/UI or by calling `systemctl restart hassos-config` on the host.
+You can put this USB stick into the device and it will be read on startup and files written to the correct places. You can also trigger this process later over the
+API/UI or by calling `systemctl restart hassos-config` on the host. *The USB Stick just needs to be insterted to the device during this setup process and can be disconnected afterwards.*
 
 ## Local
 


### PR DESCRIPTION
A question I asked myself and that got asked frequently in the forums is weather the usb stick used for configuration needs to stay within the device. So I just added some line to make this more precise.