### PR TITLE
BACKUP fs support for HassOS

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,5 +1,8 @@
 # Configuration
 
+## Alternate Backup/Snapshot File system
+Format a USB stick/Drive with a FAT32/EXT4(Best without a journal on flash)/Ext-FAT(not yet supported) file system and label it `BACKUP` case sensitive. This is mounted at configuration only if the supervisor container is not running which is usually only at boot. **It is not safe to remove this unless HassOS is powered down.**
+
 ## Automatic
 
 You can use an USB drive with HassOS to configure network options, SSH access to the host and to install updates.

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
@@ -1,0 +1,10 @@
+[Unit]
+Description=HassOS data backup partition
+
+[Mount]
+What=/dev/disk/by-label/BACKUP
+Where=/mnt/data/supervisor/backup
+Type=auto
+Options=nosuid,relatime,noexec
+SloppyOptions=yes
+

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -5,6 +5,26 @@ USB_CONFIG="/mnt/config"
 CONFIG_DIR=""
 USE_USB=0
 
+
+# Check and mount usb BACKUP to folder
+if findfs LABEL="BACKUP" > /dev/null 2>&1; then
+    echo "[Info] Found USB stick for BACKUPS"
+
+    if ! systemctl -q is-active multi-user.target; then
+        echo "[Info] Use USB stick for BACKUPS"
+        systemctl start mnt-data-supervisor-backup.mount
+        if ! systemctl -q is-active mnt-data-supervisor-backup.mount; then
+            echo "[Error] Can't mount backup partition"
+        else
+		# We can end up occasionally(first boot) mounting after the supervisor so restart
+            if systemctl -q is-active hassos-supervisor.service; then
+                 echo "[Warning] Restarting supervisor for backup filesystem"
+	         systemctl -q restart hassos-supervisor.service
+	    fi
+        fi
+    fi
+fi
+
 # Check and mount usb CONFIG to folder
 if findfs LABEL="CONFIG" > /dev/null 2>&1; then
     echo "[Info] Use USB stick for import CONFIG"


### PR DESCRIPTION
These changes are the most non invasive way I could see to add the ability to do local backups onto a different device, that didn't adversely affect boot time.

At boot config time this change mounts a filesystem labeled BACKUP to /mnt/data/supervisor/backup

This has been tested using the ova image in a virtual box both with and without BACKUP fs present.