### PR TITLE
Fix auto expand disk for GPT

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
@@ -6,28 +6,20 @@ DEVICE_CHILD="$(findfs LABEL="hassos-data")"
 DEVICE_ROOT="/dev/$(lsblk -no pkname "${DEVICE_CHILD}")"
 PART_NUM="${DEVICE_CHILD: -1}"
 
+# Need resize
+UNUSED=$(sfdisk -Fq "${DEVICE_ROOT}" | cut -d " " -f 3 | tail -1)
+if [ -z "${UNUSED}" ] || [ "${UNUSED}" -le "2048" ]; then
+    echo "[INFO] No resize of data partition needed"
+    exit 0
+fi
+
 if sfdisk -dq "${DEVICE_ROOT}" | grep -q 'label: gpt'; then
-
-    # Need resize
-    if [ "$(sgdisk -E "${DEVICE_ROOT}")" -le "2048" ]; then
-        echo "[INFO] No resize of data partition needed"
-        exit 0
-    fi
-
     # Resize & Reload partition
     echo "[INFO] Update hassos-data partition ${PART_NUM}"
     sgdisk -e "${DEVICE_ROOT}"
     sgdisk -d "${PART_NUM}" -n "${PART_NUM}:0:0" -c "${PART_NUM}:hassos-data" -t "${PART_NUM}:0FC63DAF-8483-4772-8E79-3D69D8477DE4" -u "${PART_NUM}:a52a4597-fa3a-4851-aefd-2fbe9f849079" "${DEVICE_ROOT}"
     sgdisk -v "${DEVICE_ROOT}"
 else
-
-     # Need resize
-    UNUSED=$(sfdisk -Fq "${DEVICE_ROOT}" | cut -d " " -f 3 | tail -1)
-    if [ -z "${UNUSED}" ] || [ "${UNUSED}" -le "2048" ]; then
-        echo "[INFO] No resize of data partition needed"
-        exit 0
-    fi
-
     echo ", +" | sfdisk -N "${PART_NUM}" "${DEVICE_ROOT}" --force
     sfdisk -V "${DEVICE_ROOT}"
 fi


### PR DESCRIPTION
The GPT back data structure is not moved to the end of the disk automatically when the disk size changes.

This results in the check for free blocks on a GPT partition table does not work in the current state.

The command used to check for free disk space on MBR also works on GPT tables. So moved that part to the top.

This will cause the resize to trigger on GPT tables (including moving the backup struct to the end of the disk)